### PR TITLE
Refactor/tile chunks

### DIFF
--- a/src/Game/Camera.cpp
+++ b/src/Game/Camera.cpp
@@ -7,9 +7,10 @@
 
 #include "Common.h"
 
-Camera::Camera(int worldSize)
+Camera::Camera()
 {
-    m_view.setCenter(tileToScreenPosition(worldSize, {worldSize / 2, worldSize / 2}));
+    m_view.setCenter(
+        tileToScreenPosition({CHUNK_SIZE + CHUNK_SIZE, CHUNK_SIZE + CHUNK_SIZE}));
     m_view.setSize({1600, 900});
     m_view.zoom(zoomLevel);
 }

--- a/src/Game/Camera.cpp
+++ b/src/Game/Camera.cpp
@@ -9,8 +9,7 @@
 
 Camera::Camera()
 {
-    m_view.setCenter(
-        tileToScreenPosition({CHUNK_SIZE + CHUNK_SIZE, CHUNK_SIZE + CHUNK_SIZE}));
+    m_view.setCenter(tileToScreenPosition({0, 0}));
     m_view.setSize({1600, 900});
     m_view.zoom(zoomLevel);
 }

--- a/src/Game/Camera.h
+++ b/src/Game/Camera.h
@@ -8,7 +8,7 @@ class Keyboard;
 
 class Camera {
   public:
-    Camera(int worldSize);
+    Camera();
 
     void setViewToCamera(sf::RenderWindow& window);
     void onEvent(const sf::Event& e);

--- a/src/Game/Common.h
+++ b/src/Game/Common.h
@@ -3,7 +3,7 @@
 #include <SFML/System/Vector2.hpp>
 #include <cstdint>
 
-constexpr int CHUNK_SIZE = 64;
+constexpr int CHUNK_SIZE = 128;
 
 constexpr float TILE_HEIGHT = 16.0f;
 constexpr float TILE_WIDTH = 32.0f;

--- a/src/Game/Common.h
+++ b/src/Game/Common.h
@@ -35,3 +35,20 @@ inline sf::Vector2f tileToScreenPosition(const sf::Vector2i& tilePosition)
     return {(CHUNK_SIZE * TILE_WIDTH) + (x - y) * (TILE_WIDTH / 2.0f),
             (CHUNK_SIZE * TILE_HEIGHT) + (x + y) * (TILE_HEIGHT / 2.0f)};
 }
+
+inline sf::Vector2i toChunkPosition(const sf::Vector2i& tilePosition)
+{
+    return {tilePosition.x / CHUNK_SIZE, tilePosition.y / CHUNK_SIZE};
+}
+
+inline sf::Vector2i toLocalTilePosition(const sf::Vector2i& worldTilePosition)
+{
+    return {worldTilePosition.x % CHUNK_SIZE, worldTilePosition.y % CHUNK_SIZE};
+}
+
+inline sf::Vector2i toGlobalTilePosition(const sf::Vector2i& chunkPosition,
+                                         const sf::Vector2i& localTilePosition)
+{
+    return {chunkPosition.x * CHUNK_SIZE + localTilePosition.x,
+            chunkPosition.y * CHUNK_SIZE + localTilePosition.y};
+}

--- a/src/Game/Common.h
+++ b/src/Game/Common.h
@@ -3,6 +3,8 @@
 #include <SFML/System/Vector2.hpp>
 #include <cstdint>
 
+constexpr int CHUNK_SIZE = 128;
+
 constexpr float TILE_HEIGHT = 16.0f;
 constexpr float TILE_WIDTH = 32.0f;
 
@@ -26,10 +28,10 @@ struct Vec2Compare {
     }
 };
 
-inline sf::Vector2f tileToScreenPosition(int worldSize, const sf::Vector2i& tilePosition)
+inline sf::Vector2f tileToScreenPosition(const sf::Vector2i& tilePosition)
 {
     int x = tilePosition.x;
     int y = tilePosition.y;
-    return {(worldSize * TILE_WIDTH) + (x - y) * (TILE_WIDTH / 2.0f),
-            (worldSize * TILE_HEIGHT) + (x + y) * (TILE_HEIGHT / 2.0f)};
+    return {(CHUNK_SIZE * TILE_WIDTH) + (x - y) * (TILE_WIDTH / 2.0f),
+            (CHUNK_SIZE * TILE_HEIGHT) + (x + y) * (TILE_HEIGHT / 2.0f)};
 }

--- a/src/Game/Common.h
+++ b/src/Game/Common.h
@@ -3,7 +3,7 @@
 #include <SFML/System/Vector2.hpp>
 #include <cstdint>
 
-constexpr int CHUNK_SIZE = 8;
+constexpr int CHUNK_SIZE = 64;
 
 constexpr float TILE_HEIGHT = 16.0f;
 constexpr float TILE_WIDTH = 32.0f;

--- a/src/Game/Common.h
+++ b/src/Game/Common.h
@@ -3,7 +3,7 @@
 #include <SFML/System/Vector2.hpp>
 #include <cstdint>
 
-constexpr int CHUNK_SIZE = 128;
+constexpr int CHUNK_SIZE = 8;
 
 constexpr float TILE_HEIGHT = 16.0f;
 constexpr float TILE_WIDTH = 32.0f;

--- a/src/Game/Map.cpp
+++ b/src/Game/Map.cpp
@@ -31,16 +31,6 @@ namespace {
         gridMap->emplace_back(endPosition, gridColour);
     }
 
-    sf::Vector2i toChunkPosition(const sf::Vector2i& tilePosition)
-    {
-        return {tilePosition.x / CHUNK_SIZE, tilePosition.y / CHUNK_SIZE};
-    }
-
-    sf::Vector2i toLocalTilePosition(const sf::Vector2i& worldTilePosition)
-    {
-        return {worldTilePosition.x % CHUNK_SIZE, worldTilePosition.y % CHUNK_SIZE};
-    }
-
     // https://gamedevelopment.tutsplus.com/tutorials/how-to-use-tile-bitmasking-to-auto-tile-your-level-layouts--cms-25673
     const sf::Vector2i TILE_OFFSETS[4] = {{0, 1}, {-1, 0}, {1, 0}, {0, -1}};
 
@@ -147,9 +137,9 @@ void TileChunkManager::draw(sf::RenderWindow* window)
     for (auto& chunk : m_chunks) {
         chunk.second.draw(*window, states);
     }
-    if (showDetail) {
-        window->draw(m_grid.data(), m_grid.size(), sf::Lines);
-    }
+    // if (showDetail) {
+    window->draw(m_grid.data(), m_grid.size(), sf::Lines);
+    // }
 
     for (const auto& structure : sorted) {
         const auto& str = m_structures[structure];
@@ -286,8 +276,7 @@ Tile* TileChunk::getTile(const sf::Vector2i& position)
 
 Tile* TileChunk::getGlobalTile(const sf::Vector2i& position)
 {
-    return mp_chunkManager->getTile({m_chunkPosition.x * CHUNK_SIZE + position.x,
-                                     m_chunkPosition.y * CHUNK_SIZE + position.y});
+    return mp_chunkManager->getTile(toGlobalTilePosition(m_chunkPosition, position));
 }
 
 //   ;
@@ -308,7 +297,7 @@ TileChunk::TileChunk(const sf::Vector2i& position, TileChunkManager* chunkManage
 
 void TileChunk::generateTerrain(int seed)
 {
-    m_tiles = generateWorld(m_chunkPosition, seed);
+    m_tiles = generateWorld(m_chunkPosition, mp_chunkManager, seed);
 
     for (int y = 0; y < CHUNK_SIZE; y++) {
         for (int x = 0; x < CHUNK_SIZE; x++) {

--- a/src/Game/Map.cpp
+++ b/src/Game/Map.cpp
@@ -130,12 +130,12 @@ void TileChunkManager::draw(sf::RenderWindow* window)
     for (auto& chunk : m_chunks) {
 
         chunk.second.draw(*window, states);
-        // if (showDetail) {
+        if (showDetail) {
 
-        // m_gridMap.setPosition(tileToScreenPosition(
-        //     {(chunk.first.x) * CHUNK_SIZE, chunk.first.y * CHUNK_SIZE}));
-        // m_gridMap.draw(*window);
-        // }
+         m_gridMap.setPosition(tileToScreenPosition(
+             {(chunk.first.x - 2) * CHUNK_SIZE, chunk.first.y * CHUNK_SIZE}));
+         m_gridMap.draw(*window);
+        }
     }
 
     for (const auto& structure : sorted) {
@@ -316,5 +316,5 @@ GridMap::GridMap()
 void GridMap::draw(sf::RenderTarget& window, sf::RenderStates states) const
 {
     states.transform *= getTransform();
-    window.draw(m_grid.data(), m_grid.size(), sf::Lines);
+    window.draw(m_grid.data(), m_grid.size(), sf::Lines, states);
 }

--- a/src/Game/Map.cpp
+++ b/src/Game/Map.cpp
@@ -52,13 +52,6 @@ void TileChunkManager::initWorld()
     addChunk({1, 0});
     addChunk({2, 0});
     addChunk({3, 0});
-
-    for (int i = 0; i < CHUNK_SIZE + 1; i++) {
-        addGridLine(&m_grid, tileToScreenPosition({0, i}),
-                    tileToScreenPosition({CHUNK_SIZE, i}));
-        addGridLine(&m_grid, tileToScreenPosition({i, 0}),
-                    tileToScreenPosition({i, CHUNK_SIZE}));
-    }
 }
 
 void TileChunkManager::addChunk(const sf::Vector2i& chunkPos)
@@ -135,11 +128,15 @@ void TileChunkManager::draw(sf::RenderWindow* window)
     states.texture = &m_tileTextures;
 
     for (auto& chunk : m_chunks) {
+
         chunk.second.draw(*window, states);
+        // if (showDetail) {
+
+        // m_gridMap.setPosition(tileToScreenPosition(
+        //     {(chunk.first.x) * CHUNK_SIZE, chunk.first.y * CHUNK_SIZE}));
+        // m_gridMap.draw(*window);
+        // }
     }
-    // if (showDetail) {
-    window->draw(m_grid.data(), m_grid.size(), sf::Lines);
-    // }
 
     for (const auto& structure : sorted) {
         const auto& str = m_structures[structure];
@@ -304,4 +301,20 @@ void TileChunk::generateTerrain(int seed)
             updateTile({x, y});
         }
     }
+}
+
+GridMap::GridMap()
+{
+    for (int i = 0; i < CHUNK_SIZE + 1; i++) {
+        addGridLine(&m_grid, tileToScreenPosition({0, i}),
+                    tileToScreenPosition({CHUNK_SIZE, i}));
+        addGridLine(&m_grid, tileToScreenPosition({i, 0}),
+                    tileToScreenPosition({i, CHUNK_SIZE}));
+    }
+}
+
+void GridMap::draw(sf::RenderTarget& window, sf::RenderStates states) const
+{
+    states.transform *= getTransform();
+    window.draw(m_grid.data(), m_grid.size(), sf::Lines);
 }

--- a/src/Game/Map.h
+++ b/src/Game/Map.h
@@ -17,7 +17,8 @@ class TileChunkManager;
 
 class TileChunk : public sf::Drawable, private sf::Transformable {
   public:
-    void init(const sf::Vector2i& position, TileChunkManager* chunkManager);
+    TileChunk(const sf::Vector2i& position, TileChunkManager* chunkManager);
+    void generateTerrain(int seed);
 
     void draw(sf::RenderTarget& window,
               sf::RenderStates states = sf::RenderStates::Default) const override;
@@ -31,16 +32,16 @@ class TileChunk : public sf::Drawable, private sf::Transformable {
 
     std::vector<Tile> m_tiles;
     std::vector<sf::Vertex> m_tileVerts;
-    sf::Texture* m_tileTextures;
 
     sf::Vector2i m_chunkPosition;
 
-    TileChunkManager* mp_chunkManager;
+    TileChunkManager* mp_chunkManager = nullptr;
 };
 
 class TileChunkManager {
   public:
     void initWorld();
+    void addChunk(const sf::Vector2i& chunkPos);
 
     void regenerateTerrain();
     void setTile(const sf::Vector2i& position, TileType type);
@@ -51,8 +52,6 @@ class TileChunkManager {
     bool showDetail;
 
   private:
-    void updateTile(const sf::Vector2i& position);
-
     sf::Texture m_tileTextures;
     std::unordered_map<sf::Vector2i, TileChunk, Vec2hash> m_chunks;
     std::vector<sf::Vertex> m_grid;
@@ -62,4 +61,6 @@ class TileChunkManager {
 
     sf::RectangleShape m_structureRect;
     sf::Texture m_structureMap;
+
+    int m_seed = 52323;
 };

--- a/src/Game/Map.h
+++ b/src/Game/Map.h
@@ -13,16 +13,9 @@
 #include <SFML/Graphics/VertexBuffer.hpp>
 #include <set>
 
-constexpr int CHUNK_SIZE = 16;
-
-struct TileChunk : public sf::Drawable, private sf::Transformable {
-    std::vector<Tile> tiles;
-    std::vector<sf::Vertex> m_tileVerts;
-    sf::Texture* tileTextures;
-
-    sf::Vector2i chunkPosition;
-
-    void init(const sf::Vector2i& position, int worldSize);
+class TileChunk : public sf::Drawable, private sf::Transformable {
+  public:
+    void init(const sf::Vector2i& position);
 
     void draw(sf::RenderTarget& window,
               sf::RenderStates states = sf::RenderStates::Default) const override;
@@ -30,12 +23,21 @@ struct TileChunk : public sf::Drawable, private sf::Transformable {
     void updateTile(const sf::Vector2i& position);
 
     Tile* getTile(const sf::Vector2i& position);
+
+  private:
+    std::vector<Tile> tiles;
+    std::vector<sf::Vertex> m_tileVerts;
+    sf::Texture* tileTextures;
+
+    sf::Vector2i chunkPosition;
 };
 
 struct TileChunkManager {
     std::vector<TileChunk> tilechunks;
     sf::Texture tileTextures;
     void initChunks();
+
+    void draw(sf::RenderTarget& window);
 };
 
 /*

--- a/src/Game/Map.h
+++ b/src/Game/Map.h
@@ -15,6 +15,16 @@
 
 class TileChunkManager;
 
+class GridMap : public sf::Drawable, public sf::Transformable {
+  public:
+    GridMap();
+    void draw(sf::RenderTarget& window,
+              sf::RenderStates states = sf::RenderStates::Default) const override;
+
+  private:
+    std::vector<sf::Vertex> m_grid;
+};
+
 class TileChunk : public sf::Drawable, private sf::Transformable {
   public:
     TileChunk(const sf::Vector2i& position, TileChunkManager* chunkManager);
@@ -54,13 +64,13 @@ class TileChunkManager {
   private:
     sf::Texture m_tileTextures;
     std::unordered_map<sf::Vector2i, TileChunk, Vec2hash> m_chunks;
-    std::vector<sf::Vertex> m_grid;
-
     std::unordered_map<sf::Vector2i, Structure, Vec2hash> m_structures;
     std::set<sf::Vector2i, Vec2Compare> sorted;
 
     sf::RectangleShape m_structureRect;
     sf::Texture m_structureMap;
+
+    GridMap m_gridMap;
 
     int m_seed = 52323;
 };

--- a/src/Game/Map.h
+++ b/src/Game/Map.h
@@ -13,6 +13,32 @@
 #include <SFML/Graphics/VertexBuffer.hpp>
 #include <set>
 
+constexpr int CHUNK_SIZE = 16;
+
+struct TileChunk : public sf::Drawable, private sf::Transformable {
+    std::vector<Tile> tiles;
+    std::vector<sf::Vertex> m_tileVerts;
+    sf::Texture* tileTextures;
+
+    sf::Vector2i chunkPosition;
+
+    void init(const sf::Vector2i& position, int worldSize);
+
+    void draw(sf::RenderTarget& window,
+              sf::RenderStates states = sf::RenderStates::Default) const override;
+
+    void updateTile(const sf::Vector2i& position);
+
+    Tile* getTile(const sf::Vector2i& position);
+};
+
+struct TileChunkManager {
+    std::vector<TileChunk> tilechunks;
+    sf::Texture tileTextures;
+    void initChunks();
+};
+
+/*
 struct Map {
   public:
     Map(int worldSize);
@@ -42,4 +68,4 @@ struct Map {
     sf::Texture m_structureMap;
 
     int m_worldSize;
-};
+};*/

--- a/src/Game/Map.h
+++ b/src/Game/Map.h
@@ -13,9 +13,11 @@
 #include <SFML/Graphics/VertexBuffer.hpp>
 #include <set>
 
+class TileChunkManager;
+
 class TileChunk : public sf::Drawable, private sf::Transformable {
   public:
-    void init(const sf::Vector2i& position);
+    void init(const sf::Vector2i& position, TileChunkManager* chunkManager);
 
     void draw(sf::RenderTarget& window,
               sf::RenderStates states = sf::RenderStates::Default) const override;
@@ -25,26 +27,19 @@ class TileChunk : public sf::Drawable, private sf::Transformable {
     Tile* getTile(const sf::Vector2i& position);
 
   private:
-    std::vector<Tile> tiles;
+    Tile* getGlobalTile(const sf::Vector2i& position);
+
+    std::vector<Tile> m_tiles;
     std::vector<sf::Vertex> m_tileVerts;
-    sf::Texture* tileTextures;
+    sf::Texture* m_tileTextures;
 
-    sf::Vector2i chunkPosition;
+    sf::Vector2i m_chunkPosition;
+
+    TileChunkManager* mp_chunkManager;
 };
 
-struct TileChunkManager {
-    std::vector<TileChunk> tilechunks;
-    sf::Texture tileTextures;
-    void initChunks();
-
-    void draw(sf::RenderTarget& window);
-};
-
-/*
-struct Map {
+class TileChunkManager {
   public:
-    Map(int worldSize);
-
     void initWorld();
 
     void regenerateTerrain();
@@ -59,15 +54,12 @@ struct Map {
     void updateTile(const sf::Vector2i& position);
 
     sf::Texture m_tileTextures;
-    std::vector<Tile> m_tiles;
+    std::unordered_map<sf::Vector2i, TileChunk, Vec2hash> m_chunks;
     std::vector<sf::Vertex> m_grid;
-    std::vector<sf::Vertex> m_tileVerts;
 
     std::unordered_map<sf::Vector2i, Structure, Vec2hash> m_structures;
     std::set<sf::Vector2i, Vec2Compare> sorted;
 
     sf::RectangleShape m_structureRect;
     sf::Texture m_structureMap;
-
-    int m_worldSize;
-};*/
+};

--- a/src/Game/ScreenGame.cpp
+++ b/src/Game/ScreenGame.cpp
@@ -191,7 +191,7 @@ void ScreenGame::onRender(sf::RenderWindow* window)
     m_camera.setViewToCamera(*window);
 
     // Render the tile map
-      m_tileManager.showDetail = m_camera.zoomLevel < 2;
+    m_tileManager.showDetail = m_camera.zoomLevel < 2;
     //  m_map.draw(window);
     m_tileManager.draw(window);
     // Render the selected tile

--- a/src/Game/ScreenGame.cpp
+++ b/src/Game/ScreenGame.cpp
@@ -85,9 +85,7 @@ namespace {
 
 ScreenGame::ScreenGame(ScreenManager* stack)
     : Screen(stack)
-    , m_worldSize(4)
-    //, m_map(m_worldSize)
-    , m_camera(m_worldSize)
+//, m_map(m_worldSize)
 {
     m_selectionTexture.loadFromFile("data/Textures/Selection.png");
     m_selectionQuadTexture.loadFromFile("data/Textures/SelectionQuad.png");
@@ -117,8 +115,8 @@ void ScreenGame::onInput(const Keyboard& keyboard, const sf::RenderWindow& windo
                                (int)worldPos.y % (int)TILE_HEIGHT};
 
         m_selectedTile = {
-            (cell.y - m_worldSize) + (cell.x - m_worldSize),
-            (cell.y - m_worldSize) - (cell.x - m_worldSize),
+            (cell.y - CHUNK_SIZE) + (cell.x - CHUNK_SIZE),
+            (cell.y - CHUNK_SIZE) - (cell.x - CHUNK_SIZE),
         };
 
         // clang-format off
@@ -198,15 +196,11 @@ void ScreenGame::onRender(sf::RenderWindow* window)
     // Render the tile map
     //  m_map.showDetail = m_camera.zoomLevel < 2;
     //  m_map.draw(window);
-    for (auto& chunk : m_tileManager.tilechunks) {
-        chunk.draw(*window);
-    }
+    m_tileManager.draw(*window);
     // Render the selected tile
     m_selectionRect.setTexture(&m_selectionTexture);
-    m_selectionRect.setPosition(tileToScreenPosition(m_worldSize, m_selectedTile));
+    m_selectionRect.setPosition(tileToScreenPosition(m_selectedTile));
     window->draw(m_selectionRect);
-
-
 
     if (m_quadDrag) {
         m_selectionRect.setTexture(&m_selectionQuadTexture);
@@ -224,7 +218,7 @@ void ScreenGame::onRender(sf::RenderWindow* window)
                                 ////}
                             }
                             m_selectionRect.setPosition(
-                                tileToScreenPosition(m_worldSize, tilePosition));
+                                tileToScreenPosition(tilePosition));
                             window->draw(m_selectionRect);
                         });
 

--- a/src/Game/ScreenGame.cpp
+++ b/src/Game/ScreenGame.cpp
@@ -85,8 +85,8 @@ namespace {
 
 ScreenGame::ScreenGame(ScreenManager* stack)
     : Screen(stack)
-    , m_worldSize(300)
-    , m_map(m_worldSize)
+    , m_worldSize(4)
+    //, m_map(m_worldSize)
     , m_camera(m_worldSize)
 {
     m_selectionTexture.loadFromFile("data/Textures/Selection.png");
@@ -98,7 +98,9 @@ ScreenGame::ScreenGame(ScreenManager* stack)
     registerStructures();
     registerTiles();
 
-    m_map.initWorld();
+    m_tileManager.initChunks();
+
+    // m_map.initWorld();
 }
 
 void ScreenGame::onInput(const Keyboard& keyboard, const sf::RenderWindow& window)
@@ -155,7 +157,7 @@ void ScreenGame::onGUI()
         ImGui::Text("Performance %.3f ms/frame (%.1f FPS)", 1000.0f / io.Framerate,
                     io.Framerate);
         if (ImGui::Button("Regen world")) {
-            m_map.regenerateTerrain();
+            // m_map.regenerateTerrain();
         }
     }
     ImGui::End();
@@ -172,16 +174,17 @@ void ScreenGame::onEvent(const sf::Event& e)
         }
         else if (e.type == sf::Event::MouseButtonReleased) {
             m_quadDrag = false;
-            forEachLSection(
-                m_editStartPosition, m_editPivotPoint, m_editEndPosition,
-                [&](const sf::Vector2i& tilePosition) {
-                    if (getStructure(StructureType::StoneWall).placement ==
-                        StructurePlacement::Land) {
-                        if (m_map.getTile(tilePosition)->type == TileType::Land) {
-                            m_map.placeStructure(StructureType::StoneWall, tilePosition);
-                        }
-                    }
-                });
+            forEachLSection(m_editStartPosition, m_editPivotPoint, m_editEndPosition,
+                            [&](const sf::Vector2i& tilePosition) {
+                                if (getStructure(StructureType::StoneWall).placement ==
+                                    StructurePlacement::Land) {
+                                    // if (m_map.getTile(tilePosition)->type ==
+                                    // TileType::Land) {
+                                    //    m_map.placeStructure(StructureType::StoneWall,
+                                    //    tilePosition);
+                                    //}
+                                }
+                            });
         }
     }
 }
@@ -193,13 +196,17 @@ void ScreenGame::onRender(sf::RenderWindow* window)
     m_camera.setViewToCamera(*window);
 
     // Render the tile map
-    m_map.showDetail = m_camera.zoomLevel < 2;
-    m_map.draw(window);
-
+    //  m_map.showDetail = m_camera.zoomLevel < 2;
+    //  m_map.draw(window);
+    for (auto& chunk : m_tileManager.tilechunks) {
+        chunk.draw(*window);
+    }
     // Render the selected tile
     m_selectionRect.setTexture(&m_selectionTexture);
     m_selectionRect.setPosition(tileToScreenPosition(m_worldSize, m_selectedTile));
     window->draw(m_selectionRect);
+
+
 
     if (m_quadDrag) {
         m_selectionRect.setTexture(&m_selectionQuadTexture);
@@ -208,12 +215,13 @@ void ScreenGame::onRender(sf::RenderWindow* window)
                         [&](const sf::Vector2i& tilePosition) {
                             if (getStructure(StructureType::StoneWall).placement ==
                                 StructurePlacement::Land) {
-                                if (m_map.getTile(tilePosition)->type == TileType::Land) {
-                                    m_selectionRect.setFillColor(sf::Color::Green);
-                                }
-                                else {
-                                    m_selectionRect.setFillColor(sf::Color::Red);
-                                }
+                                // if (m_map.getTile(tilePosition)->type ==
+                                // TileType::Land) {
+                                //    m_selectionRect.setFillColor(sf::Color::Green);
+                                //}
+                                // else {
+                                ///    m_selectionRect.setFillColor(sf::Color::Red);
+                                ////}
                             }
                             m_selectionRect.setPosition(
                                 tileToScreenPosition(m_worldSize, tilePosition));

--- a/src/Game/ScreenGame.cpp
+++ b/src/Game/ScreenGame.cpp
@@ -85,7 +85,6 @@ namespace {
 
 ScreenGame::ScreenGame(ScreenManager* stack)
     : Screen(stack)
-//, m_map(m_worldSize)
 {
     m_selectionTexture.loadFromFile("data/Textures/Selection.png");
     m_selectionQuadTexture.loadFromFile("data/Textures/SelectionQuad.png");
@@ -97,8 +96,6 @@ ScreenGame::ScreenGame(ScreenManager* stack)
     registerTiles();
 
     m_tileManager.initWorld();
-
-    // m_map.initWorld();
 }
 
 void ScreenGame::onInput(const Keyboard& keyboard, const sf::RenderWindow& window)
@@ -155,7 +152,7 @@ void ScreenGame::onGUI()
         ImGui::Text("Performance %.3f ms/frame (%.1f FPS)", 1000.0f / io.Framerate,
                     io.Framerate);
         if (ImGui::Button("Regen world")) {
-            // m_map.regenerateTerrain();
+            m_tileManager.regenerateTerrain();
         }
     }
     ImGui::End();
@@ -172,18 +169,17 @@ void ScreenGame::onEvent(const sf::Event& e)
         }
         else if (e.type == sf::Event::MouseButtonReleased) {
             m_quadDrag = false;
-            forEachLSection(m_editStartPosition, m_editPivotPoint, m_editEndPosition,
-                            [&](const sf::Vector2i& tilePosition) {
-                                m_tileManager.setTile({tilePosition}, TileType::Road);
-                                if (getStructure(StructureType::StoneWall).placement ==
-                                    StructurePlacement::Land) {
-                                    // if (m_map.getTile(tilePosition)->type ==
-                                    // TileType::Land) {
-                                    //    m_map.placeStructure(StructureType::StoneWall,
-                                    //    tilePosition);
-                                    //}
-                                }
-                            });
+            forEachLSection(
+                m_editStartPosition, m_editPivotPoint, m_editEndPosition,
+                [&](const sf::Vector2i& tilePosition) {
+                    if (getStructure(StructureType::StoneWall).placement ==
+                        StructurePlacement::Land) {
+                        if (m_tileManager.getTile(tilePosition)->type == TileType::Land) {
+                            m_tileManager.placeStructure(StructureType::StoneWall,
+                                                         tilePosition);
+                        }
+                    }
+                });
         }
     }
 }
@@ -206,22 +202,21 @@ void ScreenGame::onRender(sf::RenderWindow* window)
     if (m_quadDrag) {
         m_selectionRect.setTexture(&m_selectionQuadTexture);
 
-        forEachLSection(m_editStartPosition, m_editPivotPoint, m_editEndPosition,
-                        [&](const sf::Vector2i& tilePosition) {
-                            if (getStructure(StructureType::StoneWall).placement ==
-                                StructurePlacement::Land) {
-                                // if (m_map.getTile(tilePosition)->type ==
-                                // TileType::Land) {
-                                //    m_selectionRect.setFillColor(sf::Color::Green);
-                                //}
-                                // else {
-                                ///    m_selectionRect.setFillColor(sf::Color::Red);
-                                ////}
-                            }
-                            m_selectionRect.setPosition(
-                                tileToScreenPosition(tilePosition));
-                            window->draw(m_selectionRect);
-                        });
+        forEachLSection(
+            m_editStartPosition, m_editPivotPoint, m_editEndPosition,
+            [&](const sf::Vector2i& tilePosition) {
+                if (getStructure(StructureType::StoneWall).placement ==
+                    StructurePlacement::Land) {
+                    if (m_tileManager.getTile(tilePosition)->type == TileType::Land) {
+                        m_selectionRect.setFillColor(sf::Color::Green);
+                    }
+                    else {
+                        m_selectionRect.setFillColor(sf::Color::Red);
+                    }
+                }
+                m_selectionRect.setPosition(tileToScreenPosition(tilePosition));
+                window->draw(m_selectionRect);
+            });
 
         // forEachSelectedTile([&](const sf::Vector2i& tile) {
         //    m_selectionRect.setPosition(tileToScreenPosition(m_worldSize, tile));

--- a/src/Game/ScreenGame.cpp
+++ b/src/Game/ScreenGame.cpp
@@ -96,7 +96,7 @@ ScreenGame::ScreenGame(ScreenManager* stack)
     registerStructures();
     registerTiles();
 
-    m_tileManager.initChunks();
+    m_tileManager.initWorld();
 
     // m_map.initWorld();
 }
@@ -174,6 +174,7 @@ void ScreenGame::onEvent(const sf::Event& e)
             m_quadDrag = false;
             forEachLSection(m_editStartPosition, m_editPivotPoint, m_editEndPosition,
                             [&](const sf::Vector2i& tilePosition) {
+                                m_tileManager.setTile({tilePosition}, TileType::Road);
                                 if (getStructure(StructureType::StoneWall).placement ==
                                     StructurePlacement::Land) {
                                     // if (m_map.getTile(tilePosition)->type ==
@@ -196,7 +197,7 @@ void ScreenGame::onRender(sf::RenderWindow* window)
     // Render the tile map
     //  m_map.showDetail = m_camera.zoomLevel < 2;
     //  m_map.draw(window);
-    m_tileManager.draw(*window);
+    m_tileManager.draw(window);
     // Render the selected tile
     m_selectionRect.setTexture(&m_selectionTexture);
     m_selectionRect.setPosition(tileToScreenPosition(m_selectedTile));

--- a/src/Game/ScreenGame.cpp
+++ b/src/Game/ScreenGame.cpp
@@ -191,7 +191,7 @@ void ScreenGame::onRender(sf::RenderWindow* window)
     m_camera.setViewToCamera(*window);
 
     // Render the tile map
-    //  m_map.showDetail = m_camera.zoomLevel < 2;
+      m_tileManager.showDetail = m_camera.zoomLevel < 2;
     //  m_map.draw(window);
     m_tileManager.draw(window);
     // Render the selected tile

--- a/src/Game/ScreenGame.h
+++ b/src/Game/ScreenGame.h
@@ -32,7 +32,9 @@ class ScreenGame final : public Screen {
 
     int m_worldSize = 64;
 
-    Map m_map;
+    TileChunkManager m_tileManager;
+
+    // Map m_map;
     Camera m_camera;
 
     // Editor

--- a/src/Game/ScreenGame.h
+++ b/src/Game/ScreenGame.h
@@ -30,8 +30,6 @@ class ScreenGame final : public Screen {
     bool m_mousedown = false;
     sf::Mouse::Button m_buttonPressed;
 
-    int m_worldSize = 64;
-
     TileChunkManager m_tileManager;
 
     // Map m_map;

--- a/src/Game/WorldGeneration.cpp
+++ b/src/Game/WorldGeneration.cpp
@@ -18,14 +18,14 @@ struct TerrainGenOptions {
 };
 
 float getNoiseAt(const sf::Vector2i& tilePosition, const sf::Vector2i& chunkPosition,
-                 const TerrainGenOptions& options, int worldSize)
+                 const TerrainGenOptions& options)
 {
     // Get voxel X/Z positions
     // float voxelX = voxelPosition.x + chunkPosition.x * CHUNK_SIZE;
     // float voxelZ = voxelPosition.y + chunkPosition.y * CHUNK_SIZE;
 
-    float tileX = (float)(tilePosition.x + chunkPosition.x * worldSize);
-    float tileY = (float)(tilePosition.y + chunkPosition.y * worldSize);
+    float tileX = (float)(tilePosition.x + chunkPosition.x * CHUNK_SIZE);
+    float tileY = (float)(tilePosition.y + chunkPosition.y * CHUNK_SIZE);
 
     // Begin iterating through the octaves
     float value = 0;
@@ -102,9 +102,9 @@ std::vector<Tile> generateWorld(const sf::Vector2i& chunkPosition, int worldSize
     return tiles;
 }
 */
-std::vector<Tile> generateWorld(const sf::Vector2i& chunkPosition, int worldSize)
+std::vector<Tile> generateWorld(const sf::Vector2i& chunkPosition, int seed)
 {
-    std::vector<Tile> tiles(worldSize * worldSize);
+    std::vector<Tile> tiles(CHUNK_SIZE * CHUNK_SIZE);
 
     TerrainGenOptions ops;
     ops.amplitude = 20;
@@ -116,9 +116,8 @@ std::vector<Tile> generateWorld(const sf::Vector2i& chunkPosition, int worldSize
     std::mt19937 rng{rd()};
     std::uniform_real_distribution<float> pointDist(2, 6);
     std::uniform_int_distribution<int> dirDist(1, 2);
-    //std::uniform_int_distribution<int> seedDist(0, 4096);
 
-    ops.seed = 50;//seedDist(rng);
+    ops.seed = seed;
     // float riverPoint = pointDist(rng);
     // float nsOceanSize = pointDist(rng);
     // float ewOceanSize = pointDist(rng);
@@ -127,8 +126,8 @@ std::vector<Tile> generateWorld(const sf::Vector2i& chunkPosition, int worldSize
     // int riverDirection = dirDist(rng);
     // float ws = static_cast<float>(worldSize);
 
-    for (int y = 0; y < worldSize; y++) {
-        for (int x = 0; x < worldSize; x++) {
+    for (int y = 0; y < CHUNK_SIZE; y++) {
+        for (int x = 0; x < CHUNK_SIZE; x++) {
             // int rd = riverDirection == 1 ? x : y;
 
             std::vector<float> features;
@@ -141,12 +140,12 @@ std::vector<Tile> generateWorld(const sf::Vector2i& chunkPosition, int worldSize
             //  features.push_back(std::abs(rd - ws / riverPoint) / ws * 2);
 
             // Noise
-            float n = getNoiseAt({x, y}, chunkPosition, ops, worldSize);
+            float n = getNoiseAt({x, y}, chunkPosition, ops);
             features.push_back(n);
 
             float f = std::accumulate(features.begin(), features.end(), 1.0f,
                                       std::multiplies<float>());
-            tiles[x + y * worldSize].type = f > 0.4 ? TileType::Land : TileType::Water;
+            tiles[x + y * CHUNK_SIZE].type = f > 0.4 ? TileType::Land : TileType::Water;
 
             // Maybe add a tree
         }

--- a/src/Game/WorldGeneration.cpp
+++ b/src/Game/WorldGeneration.cpp
@@ -43,66 +43,9 @@ float getNoiseAt(const sf::Vector2i& tilePosition, const sf::Vector2i& chunkPosi
     }
     return value / accumulatedAmps;
 }
-/*
-std::vector<Tile> generateWorld(const sf::Vector2i& chunkPosition, int worldSize,
-                                Map* map)
-{
-    std::vector<Tile> tiles(worldSize * worldSize);
 
-    TerrainGenOptions ops;
-    ops.amplitude = 20;
-    ops.octaves = 4;
-    ops.smoothness = 100;
-    ops.roughness = 0.55f;
-
-    std::random_device rd;
-    std::mt19937 rng{rd()};
-    std::uniform_real_distribution<float> pointDist(2, 6);
-    std::uniform_int_distribution<int> dirDist(1, 2);
-    std::uniform_int_distribution<int> seedDist(0, 4096);
-
-    ops.seed = seedDist(rng);
-    // float riverPoint = pointDist(rng);
-    // float nsOceanSize = pointDist(rng);
-    // float ewOceanSize = pointDist(rng);
-    // bool isEast = dirDist(rng) == 1;
-    // bool isSouth = dirDist(rng) == 1;
-    // int riverDirection = dirDist(rng);
-    // float ws = static_cast<float>(worldSize);
-
-    for (int y = 0; y < worldSize; y++) {
-        for (int x = 0; x < worldSize; x++) {
-            // int rd = riverDirection == 1 ? x : y;
-
-            std::vector<float> features;
-
-            // Oceans
-            //  features.push_back(std::abs(x - (isEast ? 0 : ws)) / ws * ewOceanSize);
-            // features.push_back(std::abs(y - (isSouth ? 0 : ws)) / ws * nsOceanSize);
-
-            // River
-            //  features.push_back(std::abs(rd - ws / riverPoint) / ws * 2);
-
-            // Noise
-            float n = getNoiseAt({x, y}, chunkPosition, ops, worldSize);
-            features.push_back(n);
-
-            float f = std::accumulate(features.begin(), features.end(), 1.0f,
-                                      std::multiplies<float>());
-            tiles[x + y * worldSize].type = f > 0.4 ? TileType::Land : TileType::Water;
-
-            if (tiles[x + y * worldSize].type == TileType::Land && pointDist(rng) > 4 &&
-                n > 0.6) {
-                map->placeStructure(StructureType::FirTree, {x, y});
-            }
-
-            // Maybe add a tree
-        }
-    }
-    return tiles;
-}
-*/
-std::vector<Tile> generateWorld(const sf::Vector2i& chunkPosition, int seed)
+std::vector<Tile> generateWorld(const sf::Vector2i& chunkPosition, TileChunkManager* map,
+                                int seed)
 {
     std::vector<Tile> tiles(CHUNK_SIZE * CHUNK_SIZE);
 
@@ -147,7 +90,11 @@ std::vector<Tile> generateWorld(const sf::Vector2i& chunkPosition, int seed)
                                       std::multiplies<float>());
             tiles[x + y * CHUNK_SIZE].type = f > 0.4 ? TileType::Land : TileType::Water;
 
-            // Maybe add a tree
+            if (tiles[x + y * CHUNK_SIZE].type == TileType::Land && pointDist(rng) > 4 &&
+                n > 0.6) {
+                map->placeStructure(StructureType::FirTree,
+                                    toGlobalTilePosition(chunkPosition, {x, y}));
+            }
         }
     }
     return tiles;

--- a/src/Game/WorldGeneration.cpp
+++ b/src/Game/WorldGeneration.cpp
@@ -43,7 +43,7 @@ float getNoiseAt(const sf::Vector2i& tilePosition, const sf::Vector2i& chunkPosi
     }
     return value / accumulatedAmps;
 }
-
+/*
 std::vector<Tile> generateWorld(const sf::Vector2i& chunkPosition, int worldSize,
                                 Map* map)
 {
@@ -95,6 +95,58 @@ std::vector<Tile> generateWorld(const sf::Vector2i& chunkPosition, int worldSize
                 n > 0.6) {
                 map->placeStructure(StructureType::FirTree, {x, y});
             }
+
+            // Maybe add a tree
+        }
+    }
+    return tiles;
+}
+*/
+std::vector<Tile> generateWorld(const sf::Vector2i& chunkPosition, int worldSize)
+{
+    std::vector<Tile> tiles(worldSize * worldSize);
+
+    TerrainGenOptions ops;
+    ops.amplitude = 20;
+    ops.octaves = 4;
+    ops.smoothness = 100;
+    ops.roughness = 0.55f;
+
+    std::random_device rd;
+    std::mt19937 rng{rd()};
+    std::uniform_real_distribution<float> pointDist(2, 6);
+    std::uniform_int_distribution<int> dirDist(1, 2);
+    //std::uniform_int_distribution<int> seedDist(0, 4096);
+
+    ops.seed = 50;//seedDist(rng);
+    // float riverPoint = pointDist(rng);
+    // float nsOceanSize = pointDist(rng);
+    // float ewOceanSize = pointDist(rng);
+    // bool isEast = dirDist(rng) == 1;
+    // bool isSouth = dirDist(rng) == 1;
+    // int riverDirection = dirDist(rng);
+    // float ws = static_cast<float>(worldSize);
+
+    for (int y = 0; y < worldSize; y++) {
+        for (int x = 0; x < worldSize; x++) {
+            // int rd = riverDirection == 1 ? x : y;
+
+            std::vector<float> features;
+
+            // Oceans
+            //  features.push_back(std::abs(x - (isEast ? 0 : ws)) / ws * ewOceanSize);
+            // features.push_back(std::abs(y - (isSouth ? 0 : ws)) / ws * nsOceanSize);
+
+            // River
+            //  features.push_back(std::abs(rd - ws / riverPoint) / ws * 2);
+
+            // Noise
+            float n = getNoiseAt({x, y}, chunkPosition, ops, worldSize);
+            features.push_back(n);
+
+            float f = std::accumulate(features.begin(), features.end(), 1.0f,
+                                      std::multiplies<float>());
+            tiles[x + y * worldSize].type = f > 0.4 ? TileType::Land : TileType::Water;
 
             // Maybe add a tree
         }

--- a/src/Game/WorldGeneration.h
+++ b/src/Game/WorldGeneration.h
@@ -3,9 +3,5 @@
 #include "Map.h"
 #include <SFML/System/Vector2.hpp>
 
-/*
-std::vector<Tile> generateWorld(const sf::Vector2i& chunkPosition, int worldSize,
-                                Map* map);
-                                */
-
-std::vector<Tile> generateWorld(const sf::Vector2i& chunkPosition, int seed);
+std::vector<Tile> generateWorld(const sf::Vector2i& chunkPosition, TileChunkManager* map,
+                                int seed);

--- a/src/Game/WorldGeneration.h
+++ b/src/Game/WorldGeneration.h
@@ -3,5 +3,9 @@
 #include "Map.h"
 #include <SFML/System/Vector2.hpp>
 
+/*
 std::vector<Tile> generateWorld(const sf::Vector2i& chunkPosition, int worldSize,
                                 Map* map);
+                                */
+
+std::vector<Tile> generateWorld(const sf::Vector2i& chunkPosition, int worldSize);

--- a/src/Game/WorldGeneration.h
+++ b/src/Game/WorldGeneration.h
@@ -8,4 +8,4 @@ std::vector<Tile> generateWorld(const sf::Vector2i& chunkPosition, int worldSize
                                 Map* map);
                                 */
 
-std::vector<Tile> generateWorld(const sf::Vector2i& chunkPosition, int worldSize);
+std::vector<Tile> generateWorld(const sf::Vector2i& chunkPosition, int seed);


### PR DESCRIPTION
Splits the tile map into chunks so that only visible parts of the world have to been rendered, preventing major overdraw performance issues.